### PR TITLE
fix(packages/server/dockerfile): installing chalk in dockerfile to prevent server deploy failures

### DIFF
--- a/packages/server/Dockerfile
+++ b/packages/server/Dockerfile
@@ -31,8 +31,8 @@ COPY . .
 # Install tsup and typescript to build
 RUN npm install tsup typescript --save-dev
 
-# Install winston for logging
-RUN npm install winston
+# Install winston and chalk for logging
+RUN npm install winston chalk
 
 # Install the shared types package
 RUN npm install @vslint/shared


### PR DESCRIPTION
Previously failing to deploy due to missing chalk dependency in our dockerfile